### PR TITLE
SEG-17: Rename repository to `segnify-ios`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,35 +1,35 @@
 # Changelog
 All notable changes to this project will be documented in this file.
-`Segnify` adheres to [Semantic Versioning](https://semver.org/).
+`segnify-ios` adheres to [Semantic Versioning](https://semver.org/).
 
 #### 1.x Releases
 - `1.1.x` Releases - [1.1.0](#110) | [1.1.1](#111) | [1.1.2](#112)
 - `1.0.x` Releases - [1.0.0](#100) | [1.0.1](#101) | [1.0.2](#102)
 
 ---
-## [1.1.2](https://github.com/nedap/Segnify/releases/tag/1.1.2)
+## [1.1.2](https://github.com/nedap/segnify-ios/releases/tag/1.1.2)
 Released on 2018-12-20.
 
 #### Fixed
 
-- Fixed weak references to unowned objects ([#14](https://github.com/nedap/Segnify/issues/14))
+- Fixed weak references to unowned objects ([#14](https://github.com/nedap/segnify-ios/issues/14))
   - Fixed by [Bart Hopster](https://github.com/barthopster).
 
-## [1.1.1](https://github.com/nedap/Segnify/releases/tag/1.1.1)
+## [1.1.1](https://github.com/nedap/segnify-ios/releases/tag/1.1.1)
 Released on 2018-12-13.
 
 #### Added
 
-- Added `ForwardedEventsProtocol` ([#8](https://github.com/nedap/Segnify/issues/8))
-- Added support for a [banner view](https://github.com/nedap/Segnify/issues/11).
+- Added `ForwardedEventsProtocol` ([#8](https://github.com/nedap/segnify-ios/issues/8))
+- Added support for a [banner view](https://github.com/nedap/segnify-ios/issues/11).
   - Added by [Bart Hopster](https://github.com/barthopster).
 
 #### Updated
 
-- Extended the ['UIPageViewController' protocol implementations](https://github.com/nedap/Segnify/issues/8).
+- Extended the ['UIPageViewController' protocol implementations](https://github.com/nedap/segnify-ios/issues/8).
 	- Added by [Bart Hopster](https://github.com/barthopster).
 
-## [1.1.0](https://github.com/nedap/Segnify/releases/tag/1.1.0)
+## [1.1.0](https://github.com/nedap/segnify-ios/releases/tag/1.1.0)
 Released on 2018-11-28.
 
 #### Added
@@ -40,7 +40,7 @@ Released on 2018-11-28.
 - Added `SegnifyEventsProtocol`. The delegate which implements this protocol will be notified about `Segment` selection changes of `Segnify`.
 - Added `DefaultDelegates`, which offers a default implementation of almost all protocols.
 - Added the example app `Segnified` inside the Xcode project, next to the `Segnify` framework, for improved development and testing processes.
-- Added support for [infinite scrolling](https://github.com/nedap/Segnify/issues/3).
+- Added support for [infinite scrolling](https://github.com/nedap/segnify-ios/issues/3).
   - Added by [Bart Hopster](https://github.com/barthopster).
 
 #### Removed
@@ -52,7 +52,7 @@ Released on 2018-11-28.
 - Renamed all `*Configuration` protocols to `*Protocol`.
   - Updated by [Bart Hopster](https://github.com/barthopster).
   
-## [1.0.2](https://github.com/nedap/Segnify/releases/tag/1.0.2)
+## [1.0.2](https://github.com/nedap/segnify-ios/releases/tag/1.0.2)
 Released on 2018-10-25.
 
 #### Added
@@ -69,7 +69,7 @@ Released on 2018-10-25.
 - Renamed `maximumSegmentWidth` to `segmentWidth`, so it better reflects its functionality.
   - Updated by [Bart Hopster](https://github.com/barthopster).
 
-## [1.0.1](https://github.com/nedap/Segnify/releases/tag/1.0.1)
+## [1.0.1](https://github.com/nedap/segnify-ios/releases/tag/1.0.1)
 Released on 2018-10-11.
 
 #### Removed
@@ -81,7 +81,7 @@ Released on 2018-10-11.
 - Replaced usage of [SnapKit](https://snapkit.io) with the native `NSLayoutConstraint` API.
   - Updated by [Bart Hopster](https://github.com/barthopster).
 
-## [1.0.0](https://github.com/nedap/Segnify/releases/tag/1.0.0)
+## [1.0.0](https://github.com/nedap/segnify-ios/releases/tag/1.0.0)
 Released on 2018-10-02.
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 - `1.0.x` Releases - [1.0.0](#100) | [1.0.1](#101) | [1.0.2](#102)
 
 ---
+## [Unreleased]
+
+#### Updated
+- Renamed the repository to [`segnify-ios`](https://github.com/nedap/segnify-ios/issues/17).
+	- Updated by [Bart Hopster](https://github.com/barthopster).
+
 ## [1.1.2](https://github.com/nedap/segnify-ios/releases/tag/1.1.2)
 Released on 2018-12-20.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2018 N.V. Nederlandsche Apparatenfabriek (Nedap). All rights reserved.
+Copyright © 2020 N.V. Nederlandsche Apparatenfabriek (Nedap). All rights reserved.
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Segnify
+# Segnify for iOS
 
 [![Swift version](https://img.shields.io/badge/swift-4.2-brightgreen.svg)](https://img.shields.io/badge/swift-4.2-brightgreen.svg)
 [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/Segnify.svg)](https://img.shields.io/cocoapods/v/Segnify.svg)
-[![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg)](https://github.com/nedap/Segnify)
+[![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg)](https://github.com/nedap/segnify-ios)
 [![Platform](https://img.shields.io/cocoapods/p/Segnify.svg)](https://img.shields.io/cocoapods/p/Segnify.svg)
 
 An elegant, performing and fancy segmented component in Swift.
@@ -67,10 +67,10 @@ $ brew install carthage
 To integrate Segnify into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "nedap/Segnify" ~> 1.1.1
+github "nedap/segnify-ios" ~> 1.1.1
 ```
 
-Run `carthage update` to build the framework and drag the built `Segnify.framework` into your Xcode project.
+Run `carthage bootstrap` to build the framework and drag the built `Segnify.framework` into your Xcode project.
 
 ## Usage
 
@@ -183,7 +183,7 @@ extension MainViewController: SegnifyDataSourceProtocol {
 }
 ```
 
-Take a look at the [Segnified](https://github.com/nedap/Segnify/blob/master/Segnified) folder for all the details.
+Take a look at the [Segnified](https://github.com/nedap/segnify-ios/blob/master/Segnified) folder for all the details.
 
 ### Protocols
 
@@ -372,7 +372,7 @@ public class DefaultTextSegmentDelegate: TextSegmentProtocol {
 
 ## License
 
-Copyright © 2018 Nederlandsche Apparatenfabriek (Nedap) N.V.. All rights reserved.
+Copyright © 2020 Nederlandsche Apparatenfabriek (Nedap) N.V.. All rights reserved.
 
 See the [LICENSE](LICENSE) file for more info.
 

--- a/Segnify.podspec
+++ b/Segnify.podspec
@@ -2,13 +2,13 @@ Pod::Spec.new do |s|
   s.name          = 'Segnify'
   s.version       = '1.1.2'
   s.summary       = 'An elegant, performing and fancy segmented component in Swift.'
-  s.homepage      = 'https://github.com/nedap/Segnify'
+  s.homepage      = 'https://github.com/nedap/segnify-ios'
   s.license       = { :type => 'MIT', :file => 'LICENSE' }
   s.author        = { 'Bart Hopster' => 'bart.hopster@nedap.com' }
   
   s.platform      = :ios, '9.3'
   s.swift_version = '4.2'
 
-  s.source        = { :git => 'https://github.com/nedap/Segnify.git', :tag => s.version }
+  s.source        = { :git => 'https://github.com/nedap/segnify-ios.git', :tag => s.version }
   s.source_files  = 'Segnify/**/*.{swift}'
 end


### PR DESCRIPTION
***Context***
We want the repository to be more in line with the other repositories: no capital letter and `-ios` suffix.

***Relevant issues***
#17 

***Changes***
All references to the repository have been changed to `segnify-ios`. The name of the project and the framework are still named `Segnify`.

***Known problems***
- References to this framework in other apps have to be updated.

***Extra attention***
- The `CocoaPods` pod remained `Segnify`, because it fits the naming convention of pods.

***Check-list***
- [ ] Acceptance criteria in issue satisfied or Bug fixed
- [ ] Documentation present (relevant information is properly documented)
- [ ] Written tests for test suite (optional for the moment)
- [ ] Tested on devices
- [ ] CHANGELOG updated