### PR TITLE
SEG-21: Fixed broken init for Xcode 11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 - `1.0.x` Releases - [1.0.0](#100) | [1.0.1](#101) | [1.0.2](#102)
 
 ---
+## [Unreleased]
+
+#### Fixed
+- Fixed broken init in Xcode 11.4 ([#21](https://github.com/nedap/segnify-ios/issues/21))
+  - Fixed by [Yuliia Mykhailova](https://github.com/ymykhailova-nedap).
+
 ## [1.1.3](https://github.com/nedap/segnify-ios/releases/tag/1.1.3)
 Released on 2020-01-10.
 

--- a/Segnify/Views/TextSegment.swift
+++ b/Segnify/Views/TextSegment.swift
@@ -52,7 +52,7 @@ open class TextSegment: Segment {
     }
     
     @available(*, unavailable, message: "Use init(text:configuration:) instead.")
-    private override init(frame: CGRect) {
+    public override init(frame: CGRect) {
         super.init(frame: frame)
     }
     


### PR DESCRIPTION
***Context***
- Why do we want it? -> We want to be able to use the latest development tools

***Relevant issues***
- Closes #21 

***Changes***
- changed init to be `public`

***Known problems***
- none

***Extra attention***
- none

***Check-list***
- [ ] Acceptance criteria in issue satisfied or Bug fixed
- [ ] Documentation present (relevant information is properly documented)
- [ ] Written tests for test suite (optional for the moment)
- [ ] Tested on devices
- [ ] CHANGELOG updated
