### PR TITLE
SEG-22: Fix safe area constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 #### Fixed
 - Fixed broken init in Xcode 11.4 ([#21](https://github.com/nedap/segnify-ios/issues/21))
+- Fixed wrong safe area bottom constraint for `PageViewController` ([#22](https://github.com/nedap/segnify-ios/issues/22))
   - Fixed by [Yuliia Mykhailova](https://github.com/ymykhailova-nedap).
 
 ## [1.1.3](https://github.com/nedap/segnify-ios/releases/tag/1.1.3)

--- a/Segnify/View Controllers/PageViewController.swift
+++ b/Segnify/View Controllers/PageViewController.swift
@@ -131,7 +131,7 @@ open class PageViewController: UIViewController {
             NSLayoutConstraint.activate([
                 pageView.topAnchor.constraint(equalTo: segnify.bottomAnchor),
                 pageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-                pageView.bottomAnchor.constraint(equalTo: bottomLayoutGuide.topAnchor),
+                pageView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
                 pageView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
                 ], for: pageView)
         }


### PR DESCRIPTION
***Context***
- Why do we want it? -> To have the `PageViewController` stretched correctly on devices with a notch

***Relevant issues***
- Closes #22 

***Changes***
- Bottom constraint now connects to superview

***Known problems***
- none

***Extra attention***
- none

***Check-list***
- [ ] Acceptance criteria in issue satisfied or Bug fixed
- [ ] Documentation present (relevant information is properly documented)
- [ ] Written tests for test suite (optional for the moment)
- [ ] Tested on devices
- [ ] CHANGELOG updated
