### PR TITLE
Feature/33 drop support for ios 10 and 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,6 @@
 All notable changes to this project will be documented in this file.
 `segnify-ios` adheres to [Semantic Versioning](https://semver.org/).
 
-#### 1.x Releases
-- `1.1.x` Releases - [1.1.0](#110) | [1.1.1](#111) | [1.1.2](#112) | [1.1.3](#113) | [1.1.4](#114) | [1.1.5](#115)
-- `1.0.x` Releases - [1.0.0](#100) | [1.0.1](#101) | [1.0.2](#102)
-
----
 ## [Unreleased]
 
 #### Added
@@ -15,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 #### Changed
 - SEG-34: Upgrade package to Swift 5.4
+- SEG-33: Drop suppoert for iOS 10 and 11
 
 ## [1.1.6](https://github.com/nedap/segnify-ios/releases/tag/1.1.6)
 Released on 2021-01-11.

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "Segnify",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v10),
+        .iOS(.v12),
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Sources/Segnify/View Controllers/PageViewController.swift
+++ b/Sources/Segnify/View Controllers/PageViewController.swift
@@ -108,15 +108,12 @@ open class PageViewController: UIViewController {
     override open func viewDidLoad() {
         super.viewDidLoad()
         
-        // Adjusting the scroll view insets will result in a weird UI on iOS 10 and earlier.
-        automaticallyAdjustsScrollViewInsets = false
-        
         // Load up the Segnify instance.
         view.addSubview(segnify)
-        
+  
         // Give it some Auto Layout constraints.
         NSLayoutConstraint.activate([
-            segnify.topAnchor.constraint(equalTo: topLayoutGuide.bottomAnchor),
+            segnify.topAnchor.constraint(equalTo:  view.safeAreaLayoutGuide.topAnchor),
             segnify.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             segnify.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             ], for: segnify)

--- a/iOS Example/Swift Package Manager/Segnify.xcodeproj/project.pbxproj
+++ b/iOS Example/Swift Package Manager/Segnify.xcodeproj/project.pbxproj
@@ -166,7 +166,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1010;
-				LastUpgradeCheck = 1220;
+				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = "Bart Hopster";
 				TargetAttributes = {
 					20DBC35F21A6A8510068A7B1 = {
@@ -277,7 +277,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.3;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -336,7 +336,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.3;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -356,7 +356,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = 3RDHVJ3898;
 				INFOPLIST_FILE = "$(SRCROOT)/Segnified/Supporting Files/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.3;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -382,7 +382,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = 3RDHVJ3898;
 				INFOPLIST_FILE = "$(SRCROOT)/Segnified/Supporting Files/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.3;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/iOS Example/Swift Package Manager/Segnify.xcodeproj/xcshareddata/xcschemes/Segnified.xcscheme
+++ b/iOS Example/Swift Package Manager/Segnify.xcodeproj/xcshareddata/xcschemes/Segnified.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1220"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/iOS Example/Swift Package Manager/Segnify.xcodeproj/xcshareddata/xcschemes/Segnify.xcscheme
+++ b/iOS Example/Swift Package Manager/Segnify.xcodeproj/xcshareddata/xcschemes/Segnify.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1220"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
**Context**
- Why do we want/need it? -> Drop support for ios 10 and 11

**Relevant issue**
- Closes https://github.com/nedap/segnify-ios/issues/33

**Changes**
- What does it do?
- In summary, what changes are made to the code?

**Known problems**
- What problems do still arise or are anticipated?
- Which part of the solution do you need help with?

**Extra attention**
- What do I need to pay extra attention to as a reviewer?

**Check-list**
- [ ] Acceptance criteria described in the issue are satisfied, or the bug(s) is/are fixed.
- [ ] Documentation present (relevant information is properly documented).
- [ ] Written tests for test suite (optional).
- [ ] CHANGELOG updated.

**Tested on devices**
- [ ] Minimum supported iOS version.
- [ ] Maximum supported iOS version.
- [ ] Lowest resolution supported.
- [ ] Highest resolution supported.
- [ ] Device with a notch.

**Is this issue considered as Done?**
- [ ] It meets our [DoD](https://github.com/nedap/healthcare-mobile/wiki/DoD).
